### PR TITLE
Update openkis_config.local.example.php

### DIFF
--- a/extra/openkis_config.local.example.php
+++ b/extra/openkis_config.local.example.php
@@ -1,10 +1,10 @@
 <?php
 global $xmldb_mysqlhost,$xmldb_mysqldatabase,$xmldb_mysqlusername,$xmldb_mysqlpassword,$_FN_default_database_driver;
 
-$xmldb_mysqlhost = "localhost";
-$xmldb_mysqldatabase = "dbcave";
-$xmldb_mysqlusername = "root";
-$xmldb_mysqlpassword = "";
+$xmldb_mysqlhost = 'localhost';
+$xmldb_mysqldatabase = 'dbcave';
+$xmldb_mysqlusername = 'root';
+$xmldb_mysqlpassword = '';
 if ($xmldb_mysqldatabase == "")
 {
 	die("insert db config in ".__FILE__);


### PR DESCRIPTION
con i doppi apici il carattere $ nel campo password, ad esempio, viene valutato come variabile

"variables and escape sequences for special characters will not be expanded when they occur in single quoted strings"
https://www.php.net/manual/en/language.types.string.php